### PR TITLE
[fix] androidでマップ起動時に表示されていたエラーを修正

### DIFF
--- a/src/android/app/build.gradle
+++ b/src/android/app/build.gradle
@@ -50,7 +50,7 @@ android {
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
         manifestPlaceholders += [
-           googleMapApiKey: secretProperties.getProperty('googleMap.apiKey'),
+           googleMapApiKey: secretProperties.getProperty('googleMapApiKey'),
         ]
 
         minSdk = 23

--- a/src/lib/view/display_map.dart
+++ b/src/lib/view/display_map.dart
@@ -16,10 +16,8 @@ class _DisplayMapState extends State<DisplayMap> {
   @override
   void initState() {
     super.initState();
-    _getCurrentLocation();
   }
 
-  // 現在地を取得するメソッド
   void _getCurrentLocation() async {
     try {
       Position position = await Geolocator.getCurrentPosition(
@@ -62,7 +60,6 @@ class _DisplayMapState extends State<DisplayMap> {
               zoomControlsEnabled: false,
               onMapCreated: (GoogleMapController controller) {
                 mapController = controller;
-                // 現在地にカメラを移動する
                 _getCurrentLocation();
               },
             ),

--- a/src/lib/view/display_map.dart
+++ b/src/lib/view/display_map.dart
@@ -1,27 +1,41 @@
-import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
-import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:google_maps_flutter_platform_interface/google_maps_flutter_platform_interface.dart';
+import 'package:google_maps_flutter_android/google_maps_flutter_android.dart';
 
 class DisplayMap extends StatefulWidget {
+  const DisplayMap({super.key});
   @override
-  _DisplayMapState createState() => _DisplayMapState();
+  DisplayMapState createState() => DisplayMapState();
 }
 
-class _DisplayMapState extends State<DisplayMap> {
-  CameraPosition _initialLocation = CameraPosition(target: LatLng(0.0, 0.0));
+class DisplayMapState extends State<DisplayMap> {
+  CameraPosition _initialLocation = const CameraPosition(target: LatLng(0.0, 0.0));
   late GoogleMapController mapController;
 
   @override
   void initState() {
     super.initState();
+    _initializeMapRenderer();
+  }
+
+  void _initializeMapRenderer() {
+    final GoogleMapsFlutterPlatform mapsImplementation = GoogleMapsFlutterPlatform.instance;
+    if (mapsImplementation is GoogleMapsFlutterAndroid) {
+      mapsImplementation.useAndroidViewSurface = true;
+    }
+  }
+  
+  @override
+  void dispose() {
+    mapController.dispose();
+    super.dispose(); 
   }
 
   void _getCurrentLocation() async {
     try {
-      Position position = await Geolocator.getCurrentPosition(
-          desiredAccuracy: LocationAccuracy.high);
+      Position position = await Geolocator.getCurrentPosition();
 
       setState(() {
         _initialLocation = CameraPosition(
@@ -42,10 +56,10 @@ class _DisplayMapState extends State<DisplayMap> {
   @override
   Widget build(BuildContext context) {
     // 画面の幅と高さを決定する
-    var height = MediaQuery.of(context).size.height;
-    var width = MediaQuery.of(context).size.width;
+    final height = MediaQuery.of(context).size.height;
+    final width = MediaQuery.of(context).size.width;
 
-    return Container(
+    return SizedBox(
       height: height,
       width: width,
       child: Scaffold(
@@ -69,78 +83,3 @@ class _DisplayMapState extends State<DisplayMap> {
     );
   }
 }
-
-
-// class DisplayMap extends StatefulWidget {
-//   DisplayMap({Key? key}) : super(key: key);
-
-//   @override
-//   _DisplayMapState createState() => _DisplayMapState();
-// }
-
-// class _DisplayMapState extends State<DisplayMap> {
-//   late PlatformMapController _mapController;
-//   Set<Marker> _markers = {};
-
-//   @override
-//   void initState(){
-//     super.initState();
-//     _loadLocationData();
-//   }
-
-//   void _loadLocationData() {
-//     // /src/assets/data/sample_data.jsonから位置情報を読み込む
-//     const String jsonDataPath = 'assets/data/sample_data.json';
-//     DefaultAssetBundle.of(context).loadString(jsonDataPath).then((String data) {
-//       final List<dynamic> jsonList = json.decode(data);
-//       final List<LocationData> locations = jsonList.map((json) => LocationData.fromJson(json)).toList();
-//       setState(() {
-//         _markers = locations.map((location){
-//           return Marker(
-//             markerId: MarkerId(location.id),
-//             position: LatLng(location.latitude, location.longitude),
-//             infoWindow: InfoWindow(
-//               title: location.name,
-//               snippet: location.descriptionText,
-//             ),
-//           );
-//         }).toSet();
-//       });
-//     });
-
-//   }
-
-//   @override
-//   Widget build(BuildContext context) {
-//     return Scaffold(
-//       appBar: AppBar(
-//         title: Text('Display Map'),
-//       ),
-//       body: PlatformMap(
-//         onMapCreated: (controller) async {
-//           _mapController = controller;
-//           _moveCameraToCurrentLocation();
-//         },
-//         initialCameraPosition: CameraPosition(
-//           target: LatLng(0, 0),
-//           zoom: 15,
-//         ),
-//         myLocationEnabled: true,
-//         myLocationButtonEnabled: true,
-//         markers: _markers,
-//       ),
-//     );
-//   }
-
-//   // カメラを現在地に移動する関数
-//   void _moveCameraToCurrentLocation() async {
-//     Position position = await Geolocator.getCurrentPosition(
-//         desiredAccuracy: LocationAccuracy.high);
-    
-//     _mapController.moveCamera(
-//       CameraUpdate.newLatLng(
-//         LatLng(position.latitude, position.longitude),
-//       ),
-//     );
-//   }
-// }

--- a/src/pubspec.yaml
+++ b/src/pubspec.yaml
@@ -38,10 +38,11 @@ dependencies:
   cupertino_icons: ^1.0.6
   font_awesome_flutter: ^10.7.0
   email_validator: ^3.0.0
-  platform_maps_flutter: ^1.0.2
   geolocator: ^12.0.0
   google_maps_flutter: ^2.9.0
   flutter_dotenv: ^5.0.2
+  google_maps_flutter_platform_interface: ^2.9.1
+  google_maps_flutter_android: ^2.14.5
   
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 目的
andriodで発生する `E/FrameEvents(31309): updateAcquireFence: Did not find frame.`の修正

hybrid compositionという技術でどうやら解決できたようです。

参考にした記事:
https://stackoverflow.com/questions/78514657/google-maps-flutter-issues-updateacquirefence-did-not-find-frame-expecting
## マージを

- [x] 希望する
- [ ] 希望しない

## ユーザー目線でできるようになったこと(ない場合は「無し」と記入)
無し

## 動作確認方法（誰でもできるように細かく記入してください）
`flutter run`を実行後、ログインしてmapをtap